### PR TITLE
Add project boards

### DIFF
--- a/priv/repo/migrations/20150812220153_create_board.exs
+++ b/priv/repo/migrations/20150812220153_create_board.exs
@@ -1,0 +1,14 @@
+defmodule CardShark.Repo.Migrations.CreateBoard do
+  use Ecto.Migration
+
+  def change do
+    create table(:boards) do
+      add :name, :string
+      add :columns, :json
+      add :project_id, :integer
+
+      timestamps
+    end
+
+  end
+end

--- a/test/controllers/board_controller_test.exs
+++ b/test/controllers/board_controller_test.exs
@@ -1,0 +1,70 @@
+defmodule CardShark.BoardControllerTest do
+  use CardShark.ConnCase
+
+  alias CardShark.Board
+  @valid_attrs %{
+    columns: [%{name: "To Do"}, %{name: "Doing"}, %{name: "Done"}],
+    name: "The Phoenix Project",
+    project_id: 42
+  }
+  @invalid_attrs %{}
+
+  setup do
+    conn = conn() |> put_req_header("accept", "application/json")
+    {:ok, conn: conn}
+  end
+
+  test "lists all entries on index", %{conn: conn} do
+    conn = get conn, board_path(conn, :index)
+    assert json_response(conn, 200)["data"] == []
+  end
+
+  test "shows chosen resource", %{conn: conn} do
+    board = Repo.insert! %Board{}
+    conn = get conn, board_path(conn, :show, board)
+    assert json_response(conn, 200)["data"] == %{
+      "id" => board.id
+    }
+  end
+
+  test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
+    assert_raise Ecto.NoResultsError, fn ->
+      get conn, board_path(conn, :show, -1)
+    end
+  end
+
+  test "creates and renders resource when data is valid", %{conn: conn} do
+    conn = post conn, board_path(conn, :create), board: @valid_attrs
+    assert json_response(conn, 201)["data"]["id"]
+
+    board = Repo.get_by(Board, @valid_attrs |> Map.delete(:columns))
+    |> Map.take(Map.keys(@valid_attrs))
+
+    assert board == @valid_attrs
+  end
+
+  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+    conn = post conn, board_path(conn, :create), board: @invalid_attrs
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
+  test "updates and renders chosen resource when data is valid", %{conn: conn} do
+    board = Repo.insert! %Board{}
+    conn = put conn, board_path(conn, :update, board), board: @valid_attrs
+    assert json_response(conn, 200)["data"]["id"]
+    assert Repo.get_by(Board, @valid_attrs |> Map.delete(:columns))
+  end
+
+  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
+    board = Repo.insert! %Board{}
+    conn = put conn, board_path(conn, :update, board), board: @invalid_attrs
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
+  test "deletes chosen resource", %{conn: conn} do
+    board = Repo.insert! %Board{}
+    conn = delete conn, board_path(conn, :delete, board)
+    assert response(conn, 204)
+    refute Repo.get(Board, board.id)
+  end
+end

--- a/test/controllers/board_controller_test.exs
+++ b/test/controllers/board_controller_test.exs
@@ -2,6 +2,8 @@ defmodule CardShark.BoardControllerTest do
   use CardShark.ConnCase
 
   alias CardShark.Board
+  alias CardShark.Column
+
   @valid_attrs %{
     columns: [%{name: "To Do"}, %{name: "Doing"}, %{name: "Done"}],
     name: "The Phoenix Project",
@@ -38,9 +40,19 @@ defmodule CardShark.BoardControllerTest do
     assert json_response(conn, 201)["data"]["id"]
 
     board = Repo.get_by(Board, @valid_attrs |> Map.delete(:columns))
-    |> Map.take(Map.keys(@valid_attrs))
+    fields = [:name, :columns, :project_id]
 
-    assert board == @valid_attrs
+    expected = %Board{
+      name: "The Phoenix Project",
+      columns: [
+        %Column{name: "To Do"},
+        %Column{name: "Doing"},
+        %Column{name: "Done"}
+      ],
+      project_id: 42
+    }
+
+    assert Map.take(board, fields) == Map.take(expected, fields)
   end
 
   test "does not create resource and renders errors when data is invalid", %{conn: conn} do

--- a/test/models/board_test.exs
+++ b/test/models/board_test.exs
@@ -1,0 +1,18 @@
+defmodule CardShark.BoardTest do
+  use CardShark.ModelCase
+
+  alias CardShark.Board
+
+  @valid_attrs %{columns: ["To do", "Doing", "Done"], name: "My Board", project_id: 42}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = Board.changeset(%Board{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Board.changeset(%Board{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/models/board_test.exs
+++ b/test/models/board_test.exs
@@ -3,7 +3,11 @@ defmodule CardShark.BoardTest do
 
   alias CardShark.Board
 
-  @valid_attrs %{columns: ["To do", "Doing", "Done"], name: "My Board", project_id: 42}
+  @valid_attrs %{
+    columns: [%{name: "To Do"}, %{name: "Doing"}, %{name: "Done"}],
+    name: "The Phoenix Project",
+    project_id: 42
+  }
   @invalid_attrs %{}
 
   test "changeset with valid attributes" do

--- a/web/controllers/board_controller.ex
+++ b/web/controllers/board_controller.ex
@@ -1,0 +1,56 @@
+defmodule CardShark.BoardController do
+  use CardShark.Web, :controller
+
+  alias CardShark.Board
+
+  plug :scrub_params, "board" when action in [:create, :update]
+
+  def index(conn, _params) do
+    boards = Repo.all(Board)
+    render(conn, "index.json", boards: boards)
+  end
+
+  def create(conn, %{"board" => board_params}) do
+    changeset = Board.changeset(%Board{}, board_params)
+
+    case Repo.insert(changeset) do
+      {:ok, board} ->
+        conn
+        |> put_status(:created)
+        |> render("show.json", board: board)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(CardShark.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    board = Repo.get!(Board, id)
+    render conn, "show.json", board: board
+  end
+
+  def update(conn, %{"id" => id, "board" => board_params}) do
+    board = Repo.get!(Board, id)
+    changeset = Board.changeset(board, board_params)
+
+    case Repo.update(changeset) do
+      {:ok, board} ->
+        render(conn, "show.json", board: board)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(CardShark.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    board = Repo.get!(Board, id)
+
+    # Here we use delete! (with a bang) because we expect
+    # it to always work (and if it does not, it will raise).
+    board = Repo.delete!(board)
+
+    send_resp(conn, :no_content, "")
+  end
+end

--- a/web/models/board.ex
+++ b/web/models/board.ex
@@ -1,0 +1,25 @@
+defmodule CardShark.Board do
+  use CardShark.Web, :model
+
+  schema "boards" do
+    field :name, :string
+    field :columns, CardShark.ColumnList.Type
+    belongs_to :project, CardShark.Project
+
+    timestamps
+  end
+
+  @required_fields ~w(name columns project_id)
+  @optional_fields ~w()
+
+  @doc """
+  Creates a changeset based on the `model` and `params`.
+
+  If no params are provided, an invalid changeset is returned
+  with no validation performed.
+  """
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+  end
+end

--- a/web/models/column.ex
+++ b/web/models/column.ex
@@ -1,0 +1,3 @@
+defmodule CardShark.Column do
+  defstruct name: nil
+end

--- a/web/models/column_list.ex
+++ b/web/models/column_list.ex
@@ -1,0 +1,15 @@
+defmodule CardShark.ColumnList do
+  defmodule Type do
+    @behaviour Ecto.Type
+
+    def type, do: :json
+
+    def cast(payload) when is_list(payload), do: {:ok, payload}
+    def cast(%{} = payload), do: {:ok, payload}
+    def cast(_other),        do: :error
+
+    def load(value), do: Poison.decode(value, keys: :atoms!)
+
+    def dump(value), do: Poison.encode(value)
+  end
+end

--- a/web/models/column_list.ex
+++ b/web/models/column_list.ex
@@ -1,14 +1,21 @@
 defmodule CardShark.ColumnList do
+  alias CardShark.Column
+
   defmodule Type do
     @behaviour Ecto.Type
 
     def type, do: :json
 
     def cast(payload) when is_list(payload), do: {:ok, payload}
+
     def cast(%{} = payload), do: {:ok, payload}
     def cast(_other),        do: :error
 
-    def load(value), do: Poison.decode(value, keys: :atoms!)
+    def load(value) do
+      constructed = Poison.decode!(value, keys: :atoms)
+                    |> Enum.map(&(struct(Column, &1)))
+      {:ok, constructed}
+    end
 
     def dump(value), do: Poison.encode(value)
   end

--- a/web/router.ex
+++ b/web/router.ex
@@ -23,5 +23,6 @@ defmodule CardShark.Router do
     resources "/users", UserController
     resources "/cards", CardController
     resources "/projects", ProjectController
+    resources "/boards", BoardController
   end
 end

--- a/web/views/board_view.ex
+++ b/web/views/board_view.ex
@@ -1,0 +1,15 @@
+defmodule CardShark.BoardView do
+  use CardShark.Web, :view
+
+  def render("index.json", %{boards: boards}) do
+    %{data: render_many(boards, CardShark.BoardView, "board.json")}
+  end
+
+  def render("show.json", %{board: board}) do
+    %{data: render_one(board, CardShark.BoardView, "board.json")}
+  end
+
+  def render("board.json", %{board: board}) do
+    %{id: board.id}
+  end
+end


### PR DESCRIPTION
This PR introduces a "board" concept for displaying cards within a project.

It's not yet decided how cards should be associated with a board - but it should be flexible, e.g. create a board for cards with status `:backlog` or with particular tags etc

The columns for a board are stored as JSON, and deserialised into a list of `Column` structs. At this time they only have a name field, but other properties for a column, such as WIP limits etc are anticipated.
